### PR TITLE
fix multiple start errors

### DIFF
--- a/src/Update/AnimatedGifWindow.cs
+++ b/src/Update/AnimatedGifWindow.cs
@@ -71,7 +71,7 @@ namespace Squirrel.Update
                 wnd = new AnimatedGifWindow();
                 wnd.Show();
 
-                Task.Delay(TimeSpan.FromSeconds(5.0), token).ContinueWith(t => {
+                Task.Delay(TimeSpan.FromMilliseconds(100), token).ContinueWith(t => {
                     if (t.IsCanceled) return;
                     wnd.Dispatcher.BeginInvoke(new Action(() => wnd.Topmost = false));
                 });

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -98,6 +98,12 @@ namespace Squirrel.Update
                 switch (opt.updateAction) {
 #if !MONO
                 case UpdateAction.Install:
+                    var processName = Process.GetCurrentProcess().ProcessName;
+                    if (Process.GetProcesses().Count(p => p.ProcessName == processName) > 1) {
+                        this.Log().Error("More than one process like me is running running. Couldn't continue.");
+                        break;
+                    }
+
                     var progressSource = new ProgressSource();
                     if (!opt.silentInstall) {
                         AnimatedGifWindow.ShowWindow(TimeSpan.FromSeconds(4), animatedGifWindowToken.Token, progressSource);

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -98,17 +98,10 @@ namespace Squirrel.Update
                 switch (opt.updateAction) {
 #if !MONO
                 case UpdateAction.Install:
-                    var processName = Process.GetCurrentProcess().ProcessName;
-                    if (Process.GetProcesses().Count(p => p.ProcessName == processName) > 1) {
-                        this.Log().Error("More than one process like me is running running. Couldn't continue.");
-                        break;
-                    }
-
                     var progressSource = new ProgressSource();
                     if (!opt.silentInstall) {
-                        AnimatedGifWindow.ShowWindow(TimeSpan.FromSeconds(4), animatedGifWindowToken.Token, progressSource);
+                        AnimatedGifWindow.ShowWindow(TimeSpan.FromMilliseconds(100), animatedGifWindowToken.Token, progressSource);
                     }
-
                     Install(opt.silentInstall, progressSource, Path.GetFullPath(opt.target)).Wait();
                     animatedGifWindowToken.Cancel();
                     break;


### PR DESCRIPTION
During setup, if a user performs mutliple extra mouse clicks while activating the installer, it will result in an error because the code is leaving the other instances of itself alive when performing the install. The result is it tries to burn itself to the ground and the file is locked due to being in use by the other process. It subsequently throws unhandled exception errors.

This change will check the processes if there is more than one of itself running and skip the entire install task after trying to log the event.